### PR TITLE
Add openbsd to rockspec platforms

### DIFF
--- a/nvim-client-0.0.1-11.rockspec
+++ b/nvim-client-0.0.1-11.rockspec
@@ -54,6 +54,7 @@ build = {
     linux = make_plat('linux'),
     macosx = make_plat('macosx'),
     freebsd = make_plat('freebsd'),
+    openbsd = make_plat('openbsd'),
     solaris = make_plat('solaris')
     }
 }


### PR DESCRIPTION
Allow building in OpenBSD, from neovim/neovim#2445