### PR TITLE
luarocks: allow all platforms

### DIFF
--- a/nvim-client-0.0.1-12.rockspec
+++ b/nvim-client-0.0.1-12.rockspec
@@ -50,12 +50,4 @@ end
 
 build = {
   type = 'builtin',
-  platforms = {
-    linux = make_plat('linux'),
-    macosx = make_plat('macosx'),
-    freebsd = make_plat('freebsd'),
-    netbsd = make_plat('netbsd'),
-    openbsd = make_plat('openbsd'),
-    solaris = make_plat('solaris')
-  }
 }


### PR DESCRIPTION
Per https://github.com/keplerproject/luarocks/wiki/Rockspec-format we
can blacklist known incompatible platforms. In the meantime,
whitelisting platforms is a chore because it just prevents users from
building Neovim:
  - https://github.com/neovim/neovim/issues/2445
  - https://github.com/neovim/neovim/issues/2445
  - https://github.com/neovim/neovim/issues/3124