### PR TITLE
[RFC] Add support for Windows

### DIFF
--- a/nvim-client-0.0.1-15.rockspec
+++ b/nvim-client-0.0.1-15.rockspec
@@ -26,7 +26,7 @@ local function make_modules()
     ['nvim.session'] = 'nvim/session.lua',
     ['nvim.loop'] = {
       sources = {'nvim/loop.c'},
-      libraries = {'uv', 'pthread'},
+      libraries = {'uv'},
       incdirs = {"$(LIBUV_INCDIR)"},
       libdirs = {"$(LIBUV_LIBDIR)"}
     }
@@ -48,6 +48,16 @@ local function make_plat(plat)
     libs[#libs + 1] = 'dl'
   end
 
+  if plat == 'windows' then
+    libs[#libs + 1] = 'psapi'
+    libs[#libs + 1] = 'iphlpapi'
+    libs[#libs + 1] = 'userenv'
+    libs[#libs + 1] = 'ws2_32'
+    libs[#libs + 1] = 'advapi32'
+  else
+    libs[#libs + 1] = 'pthread'
+  end
+
   return { modules = modules }
 end
 
@@ -60,6 +70,7 @@ build = {
   -- https://github.com/keplerproject/luarocks/wiki/Platform-agnostic-external-dependencies
   platforms = {
     linux = make_plat('linux'),
-    freebsd = make_plat('freebsd')
+    freebsd = make_plat('freebsd'),
+    windows = make_plat('windows')
   }
 }

--- a/nvim/loop.c
+++ b/nvim/loop.c
@@ -5,7 +5,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <sys/wait.h>
+#ifndef _WIN32
+# include <sys/wait.h>
+#endif
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -173,6 +175,7 @@ static int loop_exit(lua_State *L) {
     uv_run(&uv->loop, UV_RUN_DEFAULT);
   }
 
+#ifndef _WIN32
   if (uv->transport_type == TransportTypeChild) {
     /* Work around libuv bug that leaves defunct children:
      * https://github.com/libuv/libuv/issues/154 */
@@ -180,6 +183,7 @@ static int loop_exit(lua_State *L) {
       waitpid(uv->transport.child.process.pid, &status, WNOHANG);
     }
   }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Update rockspec with windows dependencies for libuv, and guard waitpid calls. Remove pthread dependency in windows.

As far as I can tell this builds and runs with both MSVC and MinGW,