### PR TITLE
Allow lua-client to build and pass tests on Lua5.2 and Lua5.3

### DIFF
--- a/nvim-client-0.0.1-25.rockspec
+++ b/nvim-client-0.0.1-25.rockspec
@@ -9,7 +9,7 @@ description = {
   license = 'Apache'
 }
 dependencies = {
-  'lua ~> 5.1',
+  'lua >= 5.1',
   'mpack',
   'luv',
   'coxpcall'

--- a/nvim/native.c
+++ b/nvim/native.c
@@ -23,13 +23,17 @@ static int pid_wait(lua_State *L) {
 }
 #endif
 
-static const luaL_reg native_lib_f[] = {
+static const luaL_Reg native_lib_f[] = {
   {"pid_wait", pid_wait},
   {NULL, NULL}
 };
 
 int luaopen_nvim_native(lua_State *L) {
   lua_newtable(L);
+#if LUA_VERSION_NUM >= 502
+  luaL_setfuncs(L, native_lib_f, NULL);
+#else
   luaL_register(L, NULL, native_lib_f);
+#endif
   return 1;
 }


### PR DESCRIPTION
  * luaL_reg was a #define to luaL_Reg in lua5.1, it is not defined anymore
  * luaL_register does not exist anymore, use luaL_setfuncs instead