### PR TITLE
Handle stream errors before acting on the stream

### DIFF
--- a/nvim/socket_stream.lua
+++ b/nvim/socket_stream.lua
@@ -16,6 +16,9 @@ function SocketStream.open(file)
 end
 
 function SocketStream:write(data)
+  if self._stream_error then
+    error(self._stream_error)
+  end
   uv.write(self._socket, data, function(err)
     if err then
       error(self._stream_error or err)
@@ -24,6 +27,9 @@ function SocketStream:write(data)
 end
 
 function SocketStream:read_start(cb)
+  if self._stream_error then
+    error(self._stream_error)
+  end
   uv.read_start(self._socket, function(err, chunk)
     if err then
       error(err)
@@ -33,6 +39,9 @@ function SocketStream:read_start(cb)
 end
 
 function SocketStream:read_stop()
+  if self._stream_error then
+    error(self._stream_error)
+  end
   uv.read_stop(self._socket)
 end
 

--- a/nvim/tcp_stream.lua
+++ b/nvim/tcp_stream.lua
@@ -16,6 +16,9 @@ function TcpStream.open(host, port)
 end
 
 function TcpStream:write(data)
+  if self._stream_error then
+    error(self._stream_error)
+  end
   uv.write(self._socket, data, function(err)
     if err then
       error(self._stream_error or err)
@@ -24,6 +27,9 @@ function TcpStream:write(data)
 end
 
 function TcpStream:read_start(cb)
+  if self._stream_error then
+    error(self._stream_error)
+  end
   uv.read_start(self._socket, function(err, chunk)
     if err then
       error(err)
@@ -33,6 +39,9 @@ function TcpStream:read_start(cb)
 end
 
 function TcpStream:read_stop()
+  if self._stream_error then
+    error(self._stream_error)
+  end
   uv.read_stop(self._socket)
 end
 


### PR DESCRIPTION
During the setup of a Tcp/SocketStream, an error may occur which results
in self._stream_error being set.  libuv used to attempt to writing to
the stream, regardless if the stream was considered writable.

libuv/libuv@fd049399 (landed in 1.19.0, reverted in 1.19.1, and
re-landed in 1.23.0) changed uv_write to consider the writable status of
the stream.  This broke lua-client's detection of the stream open
failure, since we were only handling it when a write failure occurred.

Rather than relying on a specific stream method to fail, all stream
methods now check for self._stream_error and raise the error if it's
set.  This fixes the behavior with libuv versions that contain the
writable check, while the write method's error callback maintains the
behavior for other libuv versions.

Closes #34