### PR TITLE
session: allow precise control over returned error message

### DIFF
--- a/nvim/session.lua
+++ b/nvim/session.lua
@@ -30,11 +30,11 @@ local function coroutine_exec(func, ...)
   end
 
   resume(coroutine.create(function()
-    local status, result = copcall(func, unpack(args))
+    local status, result, flag = copcall(func, unpack(args))
     if on_complete then
       coroutine.yield(function()
         -- run the completion callback on the main thread
-        on_complete(status, result)
+        on_complete(status, result, flag)
       end)
     end
   end))
@@ -95,9 +95,9 @@ end
 
 function Session:run(request_cb, notification_cb, setup_cb, timeout)
   local function on_request(method, args, response)
-    coroutine_exec(request_cb, method, args, function(status, result)
+    coroutine_exec(request_cb, method, args, function(status, result, flag)
       if status then
-        response:send(result)
+        response:send(result, flag)
       else
         response:send(result, true)
       end

--- a/test/session_spec.lua
+++ b/test/session_spec.lua
@@ -65,7 +65,10 @@ function test_session(description, session_factory, session_destroy)
           assert.are.same({true, 1},
             {session:request('vim_eval', string.format('rpcnotify(%d, "lua_event", 2, [2])', channel_id))})
           return 'notified!'
+        elseif method == 'lua_error' then
+          return 'error message', true
         end
+
         assert.are.same('lua_method', method)
         assert.are.same({1, {1}}, args)
         return {'hello from lua!'}
@@ -88,6 +91,8 @@ function test_session(description, session_factory, session_destroy)
           {session:request('vim_eval' , string.format('rpcrequest(%d, "lua_notify")', channel_id))})
         assert.are.same({true, {'hello from lua!'}},
           {session:request('vim_eval', string.format('rpcrequest(%d, "lua_method", 1, [1])', channel_id))})
+        assert.are.same({false, {0, 'Vim:error message'}},
+          {session:request('vim_eval', string.format('rpcrequest(%d, "lua_error")', channel_id))})
         session:stop()
       end)
       assert.are.equal(6, notified)


### PR DESCRIPTION
The message returned by `pcall` et al depends on lua version, allow return of precisely specified error message. For testing https://github.com/neovim/neovim/pull/9547