### PR TITLE
Pass correct type for luaL_setfuncs' nup parameter

### DIFF
--- a/nvim/native.c
+++ b/nvim/native.c
@@ -31,7 +31,7 @@ static const luaL_Reg native_lib_f[] = {
 int luaopen_nvim_native(lua_State *L) {
   lua_newtable(L);
 #if LUA_VERSION_NUM >= 502
-  luaL_setfuncs(L, native_lib_f, NULL);
+  luaL_setfuncs(L, native_lib_f, 0);
 #else
   luaL_register(L, NULL, native_lib_f);
 #endif


### PR DESCRIPTION
```
nvim/native.c: In function ‘luaopen_nvim_native’:
nvim/native.c:34:34: warning: passing argument 3 of ‘luaL_setfuncs’ makes integer from pointer without a cast [-Wint-conversion]
   34 |   luaL_setfuncs(L, native_lib_f, NULL);
      |                                  ^~~~
      |                                  |
      |                                  void *
In file included from nvim/native.c:3:
/usr//include/lua5.2/lauxlib.h:91:71: note: expected ‘int’ but argument is of type ‘void *’
   91 | LUALIB_API void (luaL_setfuncs) (lua_State *L, const luaL_Reg *l, int nup);
      |                                                                   ~~~~^~~
```