### PR TITLE
add nvim._compat module to rockspec

### DIFF
--- a/nvim-client-0.2.1-1.rockspec
+++ b/nvim-client-0.2.1-1.rockspec
@@ -22,6 +22,7 @@ local function make_modules()
     ['nvim.stdio_stream'] = 'nvim/stdio_stream.lua',
     ['nvim.child_process_stream'] = 'nvim/child_process_stream.lua',
     ['nvim.msgpack_rpc_stream'] = 'nvim/msgpack_rpc_stream.lua',
+    ['nvim._compat'] = 'nvim/_compat.lua',
     ['nvim.session'] = 'nvim/session.lua',
     ['nvim.native'] = {
       sources = {'nvim/native.c'}


### PR DESCRIPTION
I noticed, after installing `nvim-client` from luarocks, an error requiring `nvim.session` caused by session.lua trying to require `nvim._compat`. Adding it as a published module to the rockspec appears to have fixed it when I built and tested it locally, as I was able to successfully establish a new session from outside of nvim using the new rock.