### PR TITLE
rockspec: Adding homepage

### DIFF
--- a/nvim-client-0.2.1-1.rockspec
+++ b/nvim-client-0.2.1-1.rockspec
@@ -6,7 +6,8 @@ source = {
 }
 description = {
   summary = 'Lua client to Nvim',
-  license = 'Apache'
+  license = 'Apache',
+  homepage = 'https://github.com/neovim/lua-client',
 }
 dependencies = {
   'lua >= 5.1',


### PR DESCRIPTION
master neovim tests fail on nixos due to 
`...8p-luajit-2.1.0-beta3-env/share/lua/5.1/nvim/session.lua:4: module 'nvim._compat' not found:No LuaRocks module found for nvim._compat`. As nixos lua packages are generated from the luarocks rockspecs, ot would be cool to have a release of the client to address the issue.
While at it I've added the homepage.