### PR TITLE
fix(build): make fails on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ COXPCALL ?= $(DEPS_PREFIX)/lib/luarocks/rocks/coxpcall
 CC ?= gcc
 CFLAGS ?= -g -fPIC -Wall -Wextra -Werror -Wconversion -Wextra \
 	-Wstrict-prototypes -pedantic
-LDFLAGS ?= -shared -fPIC
+LDFLAGS ?= -shared -fPIC -undefined dynamic_lookup
 DEPS_INCLUDE_FLAGS ?= -I$(DEPS_PREFIX)/include
 
 # Misc

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ The `Makefile` pulls and builds various dependencies into `.deps`.
 
      make
 
+To build on platforms other than linux, specify a `LUA_TARGET`, e.g.
+
+    LUA_TARGET=macosx build
+
+Valid `LUA_TARGET`s are those supported by lua 5.1 i.e. one of:
+  * aix
+  * ansi
+  * bsd
+  * freebsd
+  * generic
+  * linux
+  * macosx
+  * mingw
+  * posix
+  * solaris
+
 Test
 ----
 


### PR DESCRIPTION
Fix building on osx and add install instructions for non-linux platforms.

Trying to build & install on linux leads to three errors:
1. Lua doesn't build
2. libmpack doesn't build
3. neovim/lua-client doesn't build

With this PR and https://github.com/libmpack/libmpack-lua/pull/31 I'm able to build the lua client on osx.

```bash

uname -a
# Darwin hostname 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:22 PDT 2 022; root:xnu-8020.121.3~4/RELEASE_X86_64 x86_64
```

On `master`
```bash
make
# ...

# gcc -o lua  lua.o liblua.a -lm -Wl,-E -ldl -lreadline -lhistory -lncurses
# ld: unknown option: -E
# clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This error installing lua is fixed by specifying a `LUA_TARGET` of `macosx` instead of `linux`. In general, several `LUA_TARGET`s can be specified. I've added them to `README.md`. The source of truth is `make` from lua itself, e.g.

```bash
cd .deps/5.1.5/src/lua && make
# Please do
#    make PLATFORM
# where PLATFORM is one of these:
#    aix ansi bsd freebsd generic linux macosx mingw posix solaris
# See INSTALL for complete instructions.
```

The next issue is that `libmpack` doesn't build. See [libpack-lua#131](https://github.com/libmpack/libmpack-lua/pull/31). Apply the fix locally and install via:

```bash
cd ~/src/libmpack/libmpack-lua/
~/src/neovim/lua-client/.deps/usr/bin/luarocks make
```

With `libmpack` and lua installed `make` now errors with:

```
cc -g -fPIC -Wall -Wextra -Werror -Wconversion -Wextra -Wstrict-prototypes -ped
antic -o nvim/native.o -c nvim/native.c -I/Users/hjdivad/src/neovim/lua-client/
.deps/usr/include
cc -shared -fPIC nvim/native.o -o nvim/native.so
Undefined symbols for architecture x86_64:
  "_luaL_checkinteger", referenced from:
      _pid_wait in native.o
  "_luaL_register", referenced from:
      _luaopen_nvim_native in native.o
  "_lua_createtable", referenced from:
      _luaopen_nvim_native in native.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is fixed by adding `-undefined dynamic_lookup` to `LDFLAGS` and not relying on it being the default behaviour.
